### PR TITLE
Adds breakpoints option to animated progress bar

### DIFF
--- a/src/progress-bar-exercise/progress-bar-exercise.js
+++ b/src/progress-bar-exercise/progress-bar-exercise.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Button, LinearProgress } from '@mui/material'
+import { Box, Button, FormControlLabel, LinearProgress, Switch } from '@mui/material'
 import Exercise from '../core/exercise';
 import './progress-bar-exercise.scss'
 
@@ -23,6 +23,8 @@ const Solution = () => {
   const [isLoading, setIsLoading] = useState(false)
   const [progress, setProgress] = useState(0)
   const [finishRequest, setFinishRequest] = useState(false)
+  // toggle for enabling breakpoints
+  const [checked, setChecked] = useState(false)
 
   // reset local states back to default values
   const handleReset = () => {
@@ -48,6 +50,10 @@ const Solution = () => {
   const handleFinishRequest = () => {
     setIsLoading(false)
     setFinishRequest(true)
+  }
+
+  const handleSwitch = (event) => {
+    setChecked(event.target.checked)
   }
 
   const renderProgressBar = () => {
@@ -76,6 +82,7 @@ const Solution = () => {
         <Button variant="outlined" color="secondary" disabled={!isLoading} onClick={() => handleFinishRequest()}>
           Finish Request
         </Button>
+        <FormControlLabel control={<Switch checked={checked} onChange={handleSwitch} />} label="Breakpoints" />
       </Box>
     </div>
   );

--- a/src/progress-bar-exercise/progress-bar-exercise.js
+++ b/src/progress-bar-exercise/progress-bar-exercise.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Box, Button, FormControlLabel, LinearProgress, Switch } from '@mui/material'
 import Exercise from '../core/exercise';
 import './progress-bar-exercise.scss'
@@ -26,6 +26,26 @@ const Solution = () => {
   // toggle for enabling breakpoints
   const [checked, setChecked] = useState(false)
 
+  const breakpointsArr = [10, 25, 30, 65, 85]
+
+  // convert breakpoints array into an object
+  const formatBreakpoints = (arr) => {
+    let obj = {}
+    for (let i = 0; i < arr.length - 1; i++) {
+      obj[arr[i]] = arr[i]
+    }
+    return obj
+  }
+
+  const breakpointsObj = formatBreakpoints(breakpointsArr)
+
+  useEffect(() => {
+    // checks to see if breakpoints are enabled and if the progress bar is at a breakpoint
+    if (checked && progress === breakpointsObj[progress]) {
+      setTimeout(() => { console.log('Set 1 second delay') }, 1000)
+    }
+  }, [checked, progress, breakpointsObj])
+
   // reset local states back to default values
   const handleReset = () => {
     setProgress(0)
@@ -41,10 +61,10 @@ const Solution = () => {
     setIsLoading(true)
     setInterval(() => {
       setProgress((prevValue) => {
-        // 90 / 15 = 6% of progress per second
-        return Math.min(prevValue + 6, 90)
+        // increment 5% every half second
+        return Math.min(prevValue + 5, 90)
       })
-    }, 1000)
+    }, 500)
   }
 
   const handleFinishRequest = () => {

--- a/src/progress-bar-exercise/progress-bar-exercise.scss
+++ b/src/progress-bar-exercise/progress-bar-exercise.scss
@@ -36,6 +36,14 @@ button.MuiButton-outlinedSecondary {
     }
 }
 
+.MuiFormControlLabel-root {
+    margin: 20px!important;
+}
+
+.MuiFormControlLabel-label {
+    font-family: $standard-font!important;
+}
+
 .MuiLinearProgress-root {
     background-color: $gray-light!important;
 }


### PR DESCRIPTION
- Updates animated progress bar to slow animations at breakpoints
- Adds toggle to allow users to switch between a progress bar with or without breakpoints

![Screen Shot 2024-02-22 at 1 39 39 PM](https://github.com/cmlavin/futurestay-fe-takehome/assets/26473289/0ad01dcc-5cc5-4a4c-a3d8-946bd2948ec7)
